### PR TITLE
Proper main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "driver.js",
   "version": "0.1.6",
   "description": "A light-weight, no-dependency, vanilla JavaScript library to drive the user's focus across the page",
-  "main": "./assets/scripts/dist/driver.min.js",
+  "main": "dist/driver.min.js",
   "scripts": {
     "start": "node server.js",
     "build": "webpack --config webpack.config.prod.js"


### PR DESCRIPTION
Unpkg is not able to resolve `driver.js`. It gives this error `Cannot find module "./assets/scripts/dist/driver.min.js" in package driver.js@0.1.4`. Changing the `main` field to `dist/driver.min.js` should help. 

Thanks,
Faizaan.