### PR TITLE
set stage background same as hightlighted element

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -44,3 +44,4 @@ export const POPOVER_HTML = `
 
 export const OVERLAY_HTML = `<div id="${ID_OVERLAY}"></div>`;
 export const STAGE_HTML = `<div id="${ID_STAGE}"></div>`;
+export const STAGE_BACKGROUND_COLOR = '#fff';

--- a/src/core/element.js
+++ b/src/core/element.js
@@ -1,5 +1,9 @@
 import Position from './position';
-import { ANIMATION_DURATION_MS, CLASS_DRIVER_HIGHLIGHTED_ELEMENT } from '../common/constants';
+import {
+  ANIMATION_DURATION_MS,
+  CLASS_DRIVER_HIGHLIGHTED_ELEMENT,
+  STAGE_BACKGROUND_COLOR,
+} from '../common/constants';
 
 /**
  * Wrapper around DOMElements to enrich them
@@ -143,6 +147,26 @@ export default class Element {
     return position;
   }
 
+  getHighlightedElementVisualBackground(node) {
+    const target = node || this.node;
+    const background = this.getNodeBackground(target);
+    if (background) {
+      return background;
+    }
+    const parent = target.parentNode;
+    if (parent && parent.tagName !== 'HTML') {
+      return this.getHighlightedElementVisualBackground(parent);
+    }
+
+    return STAGE_BACKGROUND_COLOR;
+  }
+
+  getNodeBackground(node) {
+    const { backgroundColor } = window.getComputedStyle(node, null);
+    const transparent = backgroundColor === 'rgba(0, 0, 0, 0)';
+    return !transparent ? backgroundColor : null;
+  }
+
   /**
    * Is called when element is about to be deselected
    * i.e. when moving the focus to next element of closing
@@ -217,7 +241,9 @@ export default class Element {
    * Shows the stage behind the element
    */
   showStage() {
+    const bgColor = this.getHighlightedElementVisualBackground();
     this.stage.show(this.getCalculatedPosition());
+    this.stage.fillBackgroundColor(bgColor);
   }
 
   /**

--- a/src/core/stage.js
+++ b/src/core/stage.js
@@ -55,7 +55,6 @@ export default class Stage extends Element {
 
     this.removeNode();
   }
-
   /**
    * Makes it visible and sets the default properties
    */
@@ -65,6 +64,11 @@ export default class Stage extends Element {
     this.node.style.top = '0';
     this.node.style.bottom = '';
     this.node.style.right = '';
+    this.node.style.backgroundColor = '';
+  }
+
+  fillBackgroundColor(color) {
+    this.node.style.backgroundColor = color;
   }
 
   show(position) {


### PR DESCRIPTION
I noticed that right now the `Stage` background color is hard coded.
So if clients want to highlight other elements that are not white will look weird.
This PR utilizes `getComputedStyle` and traversing through parent nodes to get and set the actual background color.