### PR TITLE
Change rule that breaks responsive

### DIFF
--- a/demo/styles/demo.scss
+++ b/demo/styles/demo.scss
@@ -72,7 +72,7 @@ section {
   }
 
   .tagline {
-    width: 450px;
+    max-width: 450px;
     margin: 0 auto 25px;
     text-align: center;
   }


### PR DESCRIPTION
I removed a rule that breaks responsive on demo page.

Screeenshots:
Before
https://user-images.githubusercontent.com/11750180/37519655-4579d9a8-291a-11e8-9d14-9ccfe659a650.png

After
https://user-images.githubusercontent.com/11750180/37519660-48df8318-291a-11e8-85eb-cb8e9d7e4878.png

