### PR TITLE
Allow step element to be a HTMLElement

### DIFF
--- a/demo/scripts/demo.js
+++ b/demo/scripts/demo.js
@@ -3,7 +3,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   const tourSteps = [
     {
-      element: '#driver-demo-head',
+      element: document.getElementById('driver-demo-head'),
       popover: {
         title: 'Before we start',
         description: 'This is just one use-case, make sure to check out the rest of the docs below.',

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,7 @@ export default class Driver {
     this.steps = [];
 
     steps.forEach((step, index) => {
-      if (!step.element || typeof step.element !== 'string') {
+      if ((!step.element || !(typeof step.element === 'string' || step.element instanceof HTMLElement))) {
         throw new Error(`Element (query selector string) missing in step ${index}`);
       }
 
@@ -265,9 +265,10 @@ export default class Driver {
   prepareElementFromStep(currentStep, allSteps = [], index = 0) {
     let querySelector = '';
     let elementOptions = {};
+    let domElement;
 
     // If it is just a query selector string
-    if (typeof currentStep === 'string') {
+    if (typeof currentStep === 'string' || currentStep instanceof HTMLElement) {
       querySelector = currentStep;
     } else {
       querySelector = currentStep.element;
@@ -277,10 +278,14 @@ export default class Driver {
       };
     }
 
-    const domElement = this.document.querySelector(querySelector);
-    if (!domElement) {
-      console.warn(`Element to highlight ${querySelector} not found`);
-      return null;
+    if (querySelector instanceof HTMLElement) {
+      domElement = querySelector;
+    } else {
+      domElement = this.document.querySelector(querySelector);
+      if (!domElement) {
+        console.warn(`Element to highlight ${querySelector} not found`);
+        return null;
+      }
     }
 
     let popover = null;

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,7 @@ export default class Driver {
     this.steps = [];
 
     steps.forEach((step, index) => {
-      if ((!step.element || !(typeof step.element === 'string' || step.element instanceof HTMLElement))) {
+      if ((!step.element || !(typeof step.element === 'string' || step.element.nodeType > 0))) {
         throw new Error(`Element (query selector string) missing in step ${index}`);
       }
 
@@ -267,8 +267,8 @@ export default class Driver {
     let elementOptions = {};
     let domElement;
 
-    // If it is just a query selector string
-    if (typeof currentStep === 'string' || currentStep instanceof HTMLElement) {
+    // If it is just a query selector string or DOM node
+    if (typeof currentStep === 'string' || currentStep.nodeType > 0) {
       querySelector = currentStep;
     } else {
       querySelector = currentStep.element;
@@ -278,7 +278,8 @@ export default class Driver {
       };
     }
 
-    if (querySelector instanceof HTMLElement) {
+    // If it's a DOM node
+    if (querySelector.nodeType > 0) {
       domElement = querySelector;
     } else {
       domElement = this.document.querySelector(querySelector);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -138,7 +138,7 @@ declare module 'driver.js' {
       /**
        * Query selector representing the DOM Element
        */
-      element: string;
+      element: string | HTMLElement;
 
       /**
        * Color of stage when this step is active


### PR DESCRIPTION
I would find it useful to be able to pass in an existing DOM node rather than a queryString, so I think this PR should allow for that. The change in `demo.js` is just to validate it's working correctly. 