### PR TITLE
only allow going the previous step if it exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,7 @@ export default class Driver {
     if (this.steps.length !== 0) {
       if (event.keyCode === RIGHT_KEY_CODE) {
         this.moveNext();
-      } else if (event.keyCode === LEFT_KEY_CODE) {
+      } else if (event.keyCode === LEFT_KEY_CODE && this.hasPreviousStep()) {
         this.movePrevious();
       }
     }


### PR DESCRIPTION
Hi, thank you so much for the library! It's been a pleasure to use!

I noticed that once you start the driver it's possible to press the left arrow key while on the first step which closes the driver.

Would it be possible to disable the `back` key when on the first step?