### PR TITLE
onPrev, onNext and onDone event callbacks to element options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ export default class Driver {
         return;
       }
       this.overlay.highlight(this.steps[this.currentStep]);
-    } else if (!element.popover.options.isLast || !element.options.onDone || element.options.onDone(highlightedElement) !== false) {
+    } else if (!element.popover.options.isLast || !element.options.onDone || element.options.onDone(element) !== false) {
       // there is no onDone callback, or it can stop the popover close by return false
       this.reset();
     }

--- a/src/index.js
+++ b/src/index.js
@@ -108,9 +108,10 @@ export default class Driver {
     const closeClicked = e.target.classList.contains(CLASS_CLOSE_BTN);
 
     if (closeClicked) {
-      // there is no onDone callback, or it can stop the popover close by return false
-      if (!highlightedElement.options.onDone || highlightedElement.options.onDone(highlightedElement) !== false)
+      // there is no onClose callback, or it can stop the popover close by return false
+      if (!highlightedElement.options.onClose || highlightedElement.options.onClose(highlightedElement) !== false) {
         this.reset();
+      }
       return;
     }
 
@@ -197,7 +198,8 @@ export default class Driver {
         return;
       }
       this.overlay.highlight(this.steps[this.currentStep]);
-    } else {
+    } else if (!element.popover.options.isLast || !element.options.onDone || element.options.onDone(highlightedElement) !== false) {
+      // there is no onDone callback, or it can stop the popover close by return false
       this.reset();
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -166,13 +166,15 @@ export default class Driver {
    * @public
    */
   movePrevious() {
+    let element = this.steps[this.currentStep];
     this.currentStep -= 1;
     if (this.steps[this.currentStep]) {
-      let element = this.steps[this.currentStep];
-      this.overlay.highlight(element);
-      if (element.options.onPrev) {
-        element.options.onPrev(element);
+      if (element.options.onPrev && !element.options.onPrev(element)) {
+        // if the onPrev callback return false or undefined, stop go to previous
+        this.currentStep++;
+        return;
       }
+      this.overlay.highlight(this.steps[this.currentStep]);
     } else {
       this.reset();
     }
@@ -184,13 +186,15 @@ export default class Driver {
    * @public
    */
   moveNext() {
+    let element = this.steps[this.currentStep];
     this.currentStep += 1;
     if (this.steps[this.currentStep]) {
-      let element = this.steps[this.currentStep];
-      this.overlay.highlight(element);
-      if (element.options.onNext) {
-        element.options.onNext(element);
-      }      
+      if (element.options.onNext && !element.options.onNext(element)) {
+        // if the onNext callback return false or undefined, stop go to next
+        this.currentStep--;
+        return;
+      }
+      this.overlay.highlight(this.steps[this.currentStep]);
     } else {
       this.reset();
     }

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ export default class Driver {
       let element = this.steps[this.currentStep];
       this.overlay.highlight(element);
       if (element.options.onPrev) {
-        element.options.onPrev.call(element);
+        element.options.onPrev(element);
       }
     } else {
       this.reset();
@@ -189,7 +189,7 @@ export default class Driver {
       let element = this.steps[this.currentStep];
       this.overlay.highlight(element);
       if (element.options.onNext) {
-        element.options.onNext.call(element);
+        element.options.onNext(element);
       }      
     } else {
       this.reset();

--- a/src/index.js
+++ b/src/index.js
@@ -169,8 +169,8 @@ export default class Driver {
     let element = this.steps[this.currentStep];
     this.currentStep -= 1;
     if (this.steps[this.currentStep]) {
-      if (element.options.onPrev && !element.options.onPrev(element)) {
-        // if the onPrev callback return false or undefined, stop go to previous
+      if (element.options.onPrev && element.options.onPrev(element) === false) {
+        // if the onPrev callback return false, stop go to previous
         this.currentStep++;
         return;
       }
@@ -189,8 +189,8 @@ export default class Driver {
     let element = this.steps[this.currentStep];
     this.currentStep += 1;
     if (this.steps[this.currentStep]) {
-      if (element.options.onNext && !element.options.onNext(element)) {
-        // if the onNext callback return false or undefined, stop go to next
+      if (element.options.onNext && element.options.onNext(element) === false) {
+        // if the onNext callback return false, stop go to next
         this.currentStep--;
         return;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,9 @@ export default class Driver {
     const closeClicked = e.target.classList.contains(CLASS_CLOSE_BTN);
 
     if (closeClicked) {
-      this.reset();
+      // there is no onDone callback, or it can stop the popover close by return false
+      if (!highlightedElement.options.onDone || highlightedElement.options.onDone(highlightedElement) !== false)
+        this.reset();
       return;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,11 @@ export default class Driver {
   movePrevious() {
     this.currentStep -= 1;
     if (this.steps[this.currentStep]) {
-      this.overlay.highlight(this.steps[this.currentStep]);
+      let element = this.steps[this.currentStep];
+      this.overlay.highlight(element);
+      if (element.options.onPrev) {
+        element.options.onPrev.call(element);
+      }
     } else {
       this.reset();
     }
@@ -182,7 +186,11 @@ export default class Driver {
   moveNext() {
     this.currentStep += 1;
     if (this.steps[this.currentStep]) {
-      this.overlay.highlight(this.steps[this.currentStep]);
+      let element = this.steps[this.currentStep];
+      this.overlay.highlight(element);
+      if (element.options.onNext) {
+        element.options.onNext.call(element);
+      }      
     } else {
       this.reset();
     }


### PR DESCRIPTION
Add `onPrev`, `onNext` and `onDone` callbacks options to element's options.  `onStart` features can be implemented by test `options.isFirst` in the callbacks.

![image](https://user-images.githubusercontent.com/97450/39659119-0fd1fc2a-5054-11e8-8b97-817c6ea77bf5.png)

fixed issues #51 and #69