### PR TITLE
Pass the current highlightedElement onReset

### DIFF
--- a/src/core/overlay.js
+++ b/src/core/overlay.js
@@ -140,7 +140,7 @@ export default class Overlay {
   clear(immediate = false) {
     // Callback for when overlay is about to be reset
     if (this.options.onReset) {
-      this.options.onReset();
+      this.options.onReset(this.highlightedElement);
     }
 
     // Deselect the highlighted element if any


### PR DESCRIPTION
It will be easier to get the element context `onReset`, whose signature is change to `onReset: (Element) {}`