### PR TITLE
Closing on mobile, bind touchstart

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ export default class Driver {
     this.window.addEventListener('resize', this.onResize, false);
     this.window.addEventListener('keyup', this.onKeyUp, false);
     this.window.addEventListener('click', this.onClick, false);
+    this.window.addEventListener('touchstart', this.onClick, false);
   }
 
   /**


### PR DESCRIPTION
Fixes #39 

Current bindings are listening to just click events.
https://github.com/kamranahmedse/driver.js/blob/master/src/index.js#L72-L76

```
  bind() {
    this.window.addEventListener('resize', this.onResize, false);
    this.window.addEventListener('keyup', this.onKeyUp, false);
    this.window.addEventListener('click', this.onClick, false);
  }
```

I haven't tested it yet, but adding touchstart to bindings should solve the closing problem on mobile devices.

```
    this.window.addEventListener('touchstart', this.onClick, false);
```

