### PR TITLE
Add immediate param to Driver.reset in typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,7 +86,7 @@ declare module 'driver.js' {
     /**
      * Resets the steps and clears the overlay
      */
-    public reset(): void;
+    public reset(immediate?: boolean): void;
 
     /**
      * Checks if there is any highlighted element or not


### PR DESCRIPTION
Couldn't pass anything to reset in typescript without errors, now you can