### PR TITLE
Add CDN usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,12 @@ yarn add driver.js
 npm install driver.js
 ```
 
+Or include it via CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/driver.js/dist/driver.min.js"></script>
+```
+
 Or grab the code from `dist` directory and include it directly.
 
 ```html


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/driver.js) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.