### PR TITLE
Fix Typo in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ driver.highlight({
 
 ### Creating Feature Introductions – [Demo](http://kamranahmed.info/driver.js)
 
-Feature introductions are helpful when onboarding new users and giving them an idea about different parts of the application; you can create them seemlessly with Driver. Define the steps and call the `start` when you want to start presenting. User will be able to control the steps using the keyboard or using the buttons on popovers.
+Feature introductions are helpful when onboarding new users and giving them an idea about different parts of the application; you can create them seamlessly with Driver. Define the steps and call the `start` when you want to start presenting. User will be able to control the steps using the keyboard or using the buttons on popovers.
 
 ```javascript
 const driver = new Driver();


### PR DESCRIPTION
`seemlessly` 🠚 `seamlessly`