### PR TITLE
Fix type definition of Position (#139 Position Class missing types)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -612,6 +612,11 @@ declare module 'driver.js' {
                     top,
                     bottom,
                     right,
+                  }: {
+                    left: number,
+                    top: number,
+                    bottom: number,
+                    right: number
                   });
 
       /**


### PR DESCRIPTION
Missing type definition of `Position` caused tslint to throw an "implicity any error"