### PR TITLE
onRefresh hook

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -306,6 +306,7 @@ driver.highlight({
   onReset: (Element) {},        // Called when overlay is about to be cleared
   onNext: (Element) => {},      // Called when moving to next step on any step
   onPrevious: (Element) => {},  // Called when moving to next step on any step
+  onRefresh: (Element) => {},   // Called when the popover and highlighted element are repositioned
 });
 </code></pre>
     </div>

--- a/readme.md
+++ b/readme.md
@@ -206,7 +206,7 @@ driver.defineSteps([
     onNext: () => {
       // Prevent moving to the next step
       driver.preventMove();
-      
+
       // Perform some action or create the element to move to
       // And then move to that element
       setTimeout(() => {
@@ -261,6 +261,7 @@ const driver = new Driver({
   onReset: (Element) => {},            // Called when overlay is about to be cleared
   onNext: (Element) => {},                    // Called when moving to next step on any step
   onPrevious: (Element) => {},                // Called when moving to previous step on any step
+  onRefresh: (Element) => {},           // Called when the popover and highlighted element are repositioned
 });
 ```
 Note that all the button options that you provide in the driver definition can be overridden for a specific step by giving them in the step definition

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export default class Driver {
       onReset: () => null,              // When overlay is about to be cleared
       onNext: () => null,               // When next button is clicked
       onPrevious: () => null,           // When previous button is clicked
+      onRefresh: () => null,            // When the popover and highlighted element are repositioned
       ...options,
     };
 
@@ -170,6 +171,10 @@ export default class Driver {
    */
   refresh() {
     this.overlay.refresh();
+
+    if (this.options.onRefresh && this.hasHighlightedElement()) {
+      this.options.onRefresh(this.getHighlightedElement());
+    }
   }
 
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -856,6 +856,11 @@ declare module 'driver.js' {
        * Is called when the previous element is about to be highlighted
        */
       onPrevious?: (element: Driver.Element) => void;
+
+      /**
+       * Is called when the popover and highlighted element are repositioned
+       */
+      onRefresh?: (element: Driver.Element) => void;
     }
 
     interface ElementOptions extends Driver.DriverOptions {


### PR DESCRIPTION
This PR adds a handy `onRefresh` hook. 

The need for that arose in one of my projects where I have a `<textarea></textarea>` inside the description. I need to keep that textarea state in sync with other parts of the page, that's why I need to know when the UI refreshes. 

I know this is not a typical case, but nonetheless I think this can be useful for other scenarios.  