### PR TITLE
fix: Fix the bug of calling setTimeout many times but not clear

### DIFF
--- a/src/core/element.js
+++ b/src/core/element.js
@@ -358,6 +358,9 @@ export default class Element {
     }
 
     // @todo remove timeout and handle with CSS
+    if(this.animationTimeout){
+      clearTimeout(this.animationTimeout);
+    }
     this.animationTimeout = this.window.setTimeout(() => {
       this.popover.show(showAtPosition);
     }, showAfterMs);


### PR DESCRIPTION
when I meet a need that the Guide show now will hide when resizing the window of browser, but I found that when I called `driver.reset()` in `addEventListener('resize')`, it perform that the Guide I controlled reappeared after it hide, but I never do anything let it do that. after being debugged, I found the function `showPopover` in `src/core/element.js` which is called by `onResize` in `index.js` calls one more setTimeouts, but it don't be cleared before every creating. after I added those fix codes, it performed as expected. to further contact, pls email me by `gokoururi_work@163.com`