### PR TITLE
fix: highlighted element is not affected by z-index

### DIFF
--- a/src/driver.scss
+++ b/src/driver.scss
@@ -224,6 +224,7 @@ div#driver-highlighted-element-stage {
 
 .driver-fix-stacking {
   z-index: auto !important;
+  position: unset !important;
   opacity: 1.0 !important;
   transform: none !important;
   filter: none !important;


### PR DESCRIPTION
If the element to be highlighted is underneath a parent element which has a `position` property set, then that element won't be affected by `z-index` since it appears below the `.driver-page-overlay` element

Before:

<img width="332" alt="Screenshot 2021-06-05 at 6 46 22 PM" src="https://user-images.githubusercontent.com/25369014/120893090-efdd8700-c62e-11eb-9baa-f3bba2a195ae.png">

After:

<img width="339" alt="Screenshot 2021-06-05 at 6 46 33 PM" src="https://user-images.githubusercontent.com/25369014/120893096-f2d87780-c62e-11eb-87d4-d031eab2210c.png">
