### PR TITLE
Respect allowClose option when ESC key is pressed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ export default class Driver {
     }
 
     // If escape was pressed and it is allowed to click outside to close
-    if (event.keyCode === ESC_KEY_CODE) {
+    if (event.keyCode === ESC_KEY_CODE && this.options.allowClose) {
       this.reset();
       return;
     }


### PR DESCRIPTION
Hi, thanks for this neat library! I noticed that the `allowClose` option is respected on outside clicks but not when the user hits the `ESC` key. Simple enough fix though!