### PR TITLE
Add types exports path

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/driver.js.d.ts",
       "require": "./dist/driver.js.cjs",
       "import": "./dist/driver.js.mjs"
     },


### PR DESCRIPTION
This fixes the type definition missing issue when:

`moduleResolution ` is set to `Bundler` or `NodeNext` in `tsconfig.json` and `"type": "module"` is set in `package.json`.