### PR TITLE
Add validation to ensure className is a string

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -204,6 +204,7 @@ export function renderPopover(element: Element, step: DriveStep) {
       return (
         !popover?.description.contains(target) &&
         !popover?.title.contains(target) &&
+        typeof target.className === 'string' &&
         target.className.includes("driver-popover")
       );
     }


### PR DESCRIPTION
Add validation to ensure className is a string before accessing includes method for clicked element that is not an HTMLElement (In my case, injecting an SVG via onPopoverRender generates the error ``Uncaught TypeError: L.className.includes is not a function`` when it is clicked on, due to the event listener that subsequently tries to check the classes)