### PR TITLE
fix: resetState after called hooks

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -242,7 +242,6 @@ export function driver(options: Config = {}) {
     destroyOverlay();
     destroyEmitter();
 
-    resetState();
 
     if (activeElement && activeStep) {
       const isActiveDummyElement = activeElement.id === "driver-dummy-element";
@@ -260,6 +259,8 @@ export function driver(options: Config = {}) {
         });
       }
     }
+
+    resetState();
 
     if (activeOnDestroyed) {
       (activeOnDestroyed as HTMLElement).focus();


### PR DESCRIPTION
fix #401 
should resetState after called hooks, so that we can get current state at `onDestroyed`