### PR TITLE
fix: type error in the vite configuration file.

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ module.exports = defineConfig({
     rollupOptions: {
       output: {
         assetFileNames: assetInfo => {
-          return assetInfo.name === "style.css" ? `driver.css` : assetInfo.name;
+          return assetInfo.name === "style.css" ? `driver.css` : assetInfo.name as string;
         },
       },
     },


### PR DESCRIPTION
Fixed a type error in Vite.config.ts.

![image](https://github.com/kamranahmedse/driver.js/assets/32860504/f476f971-d29b-4f0a-9348-4f0a5b6e98d9)
