### PR TITLE
docs: Installation CDN example fix

### DIFF
--- a/docs/src/content/guides/installation.mdx
+++ b/docs/src/content/guides/installation.mdx
@@ -49,7 +49,8 @@ If you are using the CDN, you will have to use the package from the `window` obj
 const driver = window.driver.js.driver;
 
 const driverObj = driver();
-driver.highlight({
+
+driverObj.highlight({
   element: "#some-element",
   popover: {
     title: "Title",


### PR DESCRIPTION
I updated the documentation because with the current version example, we have this error: Uncaught TypeError: driver.highlight is not a function