### PR TITLE
Fix grammatical error

### DIFF
--- a/docs/src/components/UsecaseList.astro
+++ b/docs/src/components/UsecaseList.astro
@@ -1,7 +1,7 @@
 ---
 import UsecaseItem from "./UsecaseItem.astro";
 ---
-<p class="text-base md:text-xl lg:text-2xl text-black">Due to it's extensive API, driver.js can be used for a wide range of use
+<p class="text-base md:text-xl lg:text-2xl text-black">Due to its extensive API, driver.js can be used for a wide range of use
   cases.</p>
 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6 lg:gap-12 mt-10">
   <UsecaseItem


### PR DESCRIPTION
> It's is a contraction and should be used where a sentence would normally read "it is." The apostrophe indicates that part of a word has been removed. It's with no apostrophe, on the other hand, is the possessive word, like "his" and "her," for nouns without gender.