### PR TITLE
add license to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "driver.js",
+  "license": "MIT",
   "private": false,
   "version": "1.3.0",
   "main": "./dist/driver.js.cjs",


### PR DESCRIPTION
This project doesn't have a license property in the `package.json`, and this can cause errors when used in other projects.

<img width="469" alt="Screenshot 2023-09-20 at 10 42 38 AM" src="https://github.com/kamranahmedse/driver.js/assets/6152817/743ead9d-4b77-403f-a832-262cfa2736ab">