### PR TITLE
Allow element to be type function that returns an element

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -8,7 +8,7 @@ import { getState, resetState, setState } from "./state";
 import "./driver.css";
 
 export type DriveStep = {
-  element?: string | Element;
+  element?: string | Element | (() => Element);
   onHighlightStarted?: DriverHook;
   onHighlighted?: DriverHook;
   onDeselected?: DriverHook;

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -29,7 +29,8 @@ function mountDummyElement(): Element {
 
 export function highlight(step: DriveStep) {
   const { element } = step;
-  let elemObj = typeof element === "string" ? document.querySelector(element) : element;
+  let elemObj =
+    typeof element === "function" ? element() : typeof element === "string" ? document.querySelector(element) : element;
 
   // If the element is not found, we mount a 1px div
   // at the center of the screen to highlight and show


### PR DESCRIPTION
Adding option to use element as function that returns an element.
This makes it possible to have steps that selects elements that might not on be selectable right now but will be later on.

usage:
```typescript
const driverObj = driver({
  animate: true,
  steps: [
    {
      element: () => document.querySelector(".page-header"),
      popover: {
        title: "",
        description:"",
      },
    }
  ]
});

driverObj.drive();
```