### PR TITLE
Add new overlay and popup configuration options, allow to pass function which returns Element in element step config

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,7 @@
         <button id="backdrop-disabled-btn">Disabled backdrop</button>
         <button id="disabled-stick-to-viewport">Disabled stick to viewport</button>
         <button id="disabled-scroll">Disabled body scrolling</button>
+        <button id="disabled-same-element-animation">Disabled same element step animation</button>
         <button id="hooks">Hooks</button>
         <button id="destroy-btn" style="border-color: red; background: red; color: white">Destroy</button>
       </div>
@@ -367,6 +368,77 @@ npm install driver.js</pre
           element: ".page-header h1",
           popover: {
             title: "No Stacking Issues",
+            description:
+              "Unlike the older version, new version doesn't work with z-indexes so no more positional issues.",
+            side: "left",
+            align: "start",
+          },
+        },
+        {
+          element: ".page-header sup",
+          popover: {
+            title: "Improved Hooks",
+            description:
+              "Unlike the older version, new version doesn't work with z-indexes so no more positional issues.",
+            side: "bottom",
+            align: "start",
+          },
+        },
+        {
+          popover: {
+            title: "No Element",
+            description: "You can now have popovers without elements as well",
+          },
+        },
+        {
+          element: '.buttons',
+          popover: {
+            title: "Buttons",
+            description: "Here are some buttons",
+          },
+        },
+        {
+          element: "#scrollable-area",
+          popover: {
+            title: "Scrollable Areas",
+            description: "There are no issues with scrollable element tours as well.",
+          },
+        },
+        {
+          element: "#third-scroll-paragraph",
+          popover: {
+            title: "Nested Scrolls",
+            description: "Even the nested scrollable elements work now.",
+          },
+        },
+      ];
+
+
+      const sameElementSteps = [
+        {
+          element: ".page-header h1",
+          popover: {
+            title: "1 popup on the same element",
+            description:
+              "Unlike the older version, new version doesn't work with z-indexes so no more positional issues.",
+            side: "left",
+            align: "start",
+          },
+        },
+        {
+          element: ".page-header h1",
+          popover: {
+            title: "2 popup on the same element",
+            description:
+              "Unlike the older version, new version doesn't work with z-indexes so no more positional issues.",
+            side: "left",
+            align: "start",
+          },
+        },
+        {
+          element: ".page-header h1",
+          popover: {
+            title: "3 popup on the same element",
             description:
               "Unlike the older version, new version doesn't work with z-indexes so no more positional issues.",
             side: "left",
@@ -907,6 +979,16 @@ npm install driver.js</pre
         const driverObj = driver({
           allowScroll: false,
           steps: basicTourSteps,
+        });
+
+        driverObj.drive();
+      });
+
+      document.getElementById("disabled-same-element-animation").addEventListener("click", () => {
+        const driverObj = driver({
+          allowScroll: false,
+          animateBetweenSameElements: false,
+          steps: sameElementSteps,
         });
 
         driverObj.drive();

--- a/index.html
+++ b/index.html
@@ -177,6 +177,8 @@
         <button id="is-active-btn">Is Active?</button>
         <button id="activate-check-btn">Activate and Check</button>
         <button id="backdrop-color-btn">Backdrop Color</button>
+        <button id="backdrop-disabled-btn">Disabled backdrop</button>
+        <button id="disabled-stick-to-viewport">Disabled stick to viewport</button>
         <button id="hooks">Hooks</button>
         <button id="destroy-btn" style="border-color: red; background: red; color: white">Destroy</button>
       </div>
@@ -875,6 +877,30 @@ npm install driver.js</pre
         }).highlight({
           element: "#backdrop-color-btn",
         });
+      });
+
+      document.getElementById("backdrop-disabled-btn").addEventListener("click", () => {
+        driver({
+          overlayEnable: false,
+        }).highlight({
+          element: "h2",
+          popover: {
+            title: "MIT License",
+            description: "A lightweight, no-dependency JavaScript engine to drive user's focus.",
+            side: "bottom",
+            align: "start",
+          },
+        });;
+      });
+
+      document.getElementById("disabled-stick-to-viewport").addEventListener("click", () => {
+        const driverObj = driver({
+          popoverStickToViewport: false,
+          overlayEnable: false,
+          steps: basicTourSteps
+        });
+
+        driverObj.drive();
       });
 
       document.getElementById("activate-check-btn").addEventListener("click", () => {

--- a/index.html
+++ b/index.html
@@ -986,7 +986,6 @@ npm install driver.js</pre
 
       document.getElementById("disabled-same-element-animation").addEventListener("click", () => {
         const driverObj = driver({
-          allowScroll: false,
           animateBetweenSameElements: false,
           steps: sameElementSteps,
         });

--- a/index.html
+++ b/index.html
@@ -179,6 +179,7 @@
         <button id="backdrop-color-btn">Backdrop Color</button>
         <button id="backdrop-disabled-btn">Disabled backdrop</button>
         <button id="disabled-stick-to-viewport">Disabled stick to viewport</button>
+        <button id="disabled-scroll">Disabled body scrolling</button>
         <button id="hooks">Hooks</button>
         <button id="destroy-btn" style="border-color: red; background: red; color: white">Destroy</button>
       </div>
@@ -896,8 +897,16 @@ npm install driver.js</pre
       document.getElementById("disabled-stick-to-viewport").addEventListener("click", () => {
         const driverObj = driver({
           popoverStickToViewport: false,
-          overlayEnable: false,
-          steps: basicTourSteps
+          steps: basicTourSteps,
+        });
+
+        driverObj.drive();
+      });
+
+      document.getElementById("disabled-scroll").addEventListener("click", () => {
+        const driverObj = driver({
+          allowScroll: false,
+          steps: basicTourSteps,
         });
 
         driverObj.drive();

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export type Config = {
   overlayOpacity?: number;
   smoothScroll?: boolean;
   allowClose?: boolean;
+  allowScroll?: boolean;
   stagePadding?: number;
   stageRadius?: number;
 
@@ -56,6 +57,7 @@ export function configure(config: Config = {}) {
   currentConfig = {
     animate: true,
     allowClose: true,
+    allowScroll: true,
     overlayOpacity: 0.7,
     overlayEnable: true,
     smoothScroll: false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export type Config = {
   steps?: DriveStep[];
 
   animate?: boolean;
+  animateBetweenSameElements?: boolean
   overlayEnable?: boolean;
   overlayColor?: string;
   overlayOpacity?: number;
@@ -56,6 +57,7 @@ let currentConfig: Config = {};
 export function configure(config: Config = {}) {
   currentConfig = {
     animate: true,
+    animateBetweenSameElements: true,
     allowClose: true,
     allowScroll: true,
     overlayOpacity: 0.7,

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export type Config = {
   steps?: DriveStep[];
 
   animate?: boolean;
+  overlayEnable?: boolean;
   overlayColor?: string;
   overlayOpacity?: number;
   smoothScroll?: boolean;
@@ -55,6 +56,7 @@ export function configure(config: Config = {}) {
     animate: true,
     allowClose: true,
     overlayOpacity: 0.7,
+    overlayEnable: true,
     smoothScroll: false,
     disableActiveInteraction: false,
     showProgress: false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export type Config = {
   // Popover specific configuration
   popoverClass?: string;
   popoverOffset?: number;
+  popoverStickToViewport?: boolean;
   showButtons?: AllowedButtons[];
   disableButtons?: AllowedButtons[];
   showProgress?: boolean;
@@ -63,6 +64,7 @@ export function configure(config: Config = {}) {
     stagePadding: 10,
     stageRadius: 5,
     popoverOffset: 10,
+    popoverStickToViewport: true,
     showButtons: ["next", "previous", "close"],
     disableButtons: [],
     overlayColor: "#000",

--- a/src/driver.css
+++ b/src/driver.css
@@ -2,7 +2,7 @@
   pointer-events: none;
 }
 
-.driver-active * {
+.driver-active:not(.driver-no-overlay) * {
   pointer-events: none;
 }
 

--- a/src/driver.css
+++ b/src/driver.css
@@ -31,7 +31,7 @@
   animation: animate-fade-in 200ms ease-in-out;
 }
 
-.driver-fade .driver-popover {
+.driver-fade .driver-popover:not(.driver-no-animation) {
   animation: animate-fade-in 200ms;
 }
 

--- a/src/driver.css
+++ b/src/driver.css
@@ -2,6 +2,10 @@
   pointer-events: none;
 }
 
+.driver-active.driver-no-scroll {
+  overflow: hidden;
+}
+
 .driver-active:not(.driver-no-overlay) * {
   pointer-events: none;
 }

--- a/src/driver.css
+++ b/src/driver.css
@@ -8,8 +8,8 @@
 
 .driver-active .driver-active-element,
 .driver-active .driver-active-element *,
-.driver-popover,
-.driver-popover * {
+.driver-active .driver-popover,
+.driver-active .driver-popover * {
   pointer-events: auto;
 }
 

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -127,6 +127,10 @@ export function driver(options: Config = {}) {
     setState("isInitialized", true);
     document.body.classList.add("driver-active", getConfig("animate") ? "driver-fade" : "driver-simple");
 
+    if(!getConfig("overlayEnable")){
+      document.body.classList.add("driver-no-overlay");
+    }
+
     initEvents();
 
     listen("overlayClick", handleClose);

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -8,7 +8,7 @@ import { getState, resetState, setState } from "./state";
 import "./driver.css";
 
 export type DriveStep = {
-  element?: string | Element;
+  element?: string | Element | (() => Element);
   onHighlightStarted?: DriverHook;
   onHighlighted?: DriverHook;
   onDeselected?: DriverHook;

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -8,7 +8,7 @@ import { getState, resetState, setState } from "./state";
 import "./driver.css";
 
 export type DriveStep = {
-  element?: string | Element | (() => Element);
+  element?: string | Element | (() => Element | null);
   onHighlightStarted?: DriverHook;
   onHighlighted?: DriverHook;
   onDeselected?: DriverHook;

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -127,14 +127,6 @@ export function driver(options: Config = {}) {
     setState("isInitialized", true);
     document.body.classList.add("driver-active", getConfig("animate") ? "driver-fade" : "driver-simple");
 
-    if (!getConfig("overlayEnable")) {
-      document.body.classList.add("driver-no-overlay");
-    }
-
-    if (!getConfig("allowScroll")) {
-      document.body.classList.add("driver-no-scroll");
-    }
-
     initEvents();
 
     listen("overlayClick", handleClose);
@@ -243,7 +235,7 @@ export function driver(options: Config = {}) {
     const onDeselected = activeStep?.onDeselected || getConfig("onDeselected");
     const onDestroyed = getConfig("onDestroyed");
 
-    document.body.classList.remove("driver-active", "driver-fade", "driver-simple");
+    document.body.classList.remove("driver-active", "driver-fade", "driver-simple", "driver-no-overlay", "driver-no-scroll");
 
     destroyEvents();
     destroyPopover();

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -127,8 +127,12 @@ export function driver(options: Config = {}) {
     setState("isInitialized", true);
     document.body.classList.add("driver-active", getConfig("animate") ? "driver-fade" : "driver-simple");
 
-    if(!getConfig("overlayEnable")){
+    if (!getConfig("overlayEnable")) {
       document.body.classList.add("driver-no-overlay");
+    }
+
+    if (!getConfig("allowScroll")) {
+      document.body.classList.add("driver-no-scroll");
     }
 
     initEvents();

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -135,6 +135,7 @@ export function driver(options: Config = {}) {
 
     listen("overlayClick", handleClose);
     listen("escapePress", handleClose);
+    listen("windowClick", handleClose);
     listen("arrowLeftPress", handleArrowLeft);
     listen("arrowRightPress", handleArrowRight);
   }

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -5,7 +5,8 @@ type allowedEvents =
   | "prevClick"
   | "closeClick"
   | "arrowRightPress"
-  | "arrowLeftPress";
+  | "arrowLeftPress"
+  | "windowClick";
 
 let registeredListeners: Partial<{ [key in allowedEvents]: () => void }> = {};
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,6 +4,16 @@ import { getState, setState } from "./state";
 import { getConfig } from "./config";
 import { getFocusableElements } from "./utils";
 
+function onWindowClick(e: MouseEvent) {
+  const isPopoverContent = (e.target as HTMLElement)?.closest('#driver-popover-content')
+  const isActive = getState('activeStep')
+  const isTransitioning = getState("__transitionCallback")
+
+  if (isTransitioning || !isActive || isPopoverContent) return;
+
+  emit('windowClick')
+}
+
 export function requireRefresh() {
   const resizeTimeout = getState("__resizeTimeout");
   if (resizeTimeout) {
@@ -118,10 +128,14 @@ export function initEvents() {
   window.addEventListener("keydown", trapFocus, false);
   window.addEventListener("resize", requireRefresh);
   window.addEventListener("scroll", requireRefresh);
+  if (!getConfig('overlayEnable')) {
+    window.addEventListener('click', onWindowClick)
+  }
 }
 
 export function destroyEvents() {
   window.removeEventListener("keyup", onKeyup);
   window.removeEventListener("resize", requireRefresh);
   window.removeEventListener("scroll", requireRefresh);
+  window.removeEventListener("click", onWindowClick);
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -5,6 +5,9 @@ import { getConfig } from "./config";
 import { getFocusableElements } from "./utils";
 
 function onWindowClick(e: MouseEvent) {
+  const isOverlayEnabled = getConfig('overlayEnable')
+  if (isOverlayEnabled) return;
+
   const isPopoverContent = (e.target as HTMLElement)?.closest('#driver-popover-content')
   const isActive = getState('activeStep')
   const isTransitioning = getState("__transitionCallback")

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -75,11 +75,12 @@ function transferHighlight(toElement: Element, toStep: DriveStep) {
 
   const fromStep = getState("__activeStep");
   const fromElement = getState("__activeElement") || toElement;
+  const isSameElement = fromElement === toElement;
 
   // If it's the first time we're highlighting an element, we show
   // the popover immediately. Otherwise, we wait for the animation
   // to finish before showing the popover.
-  const isFirstHighlight = !fromElement || fromElement === toElement;
+  const isFirstHighlight = !fromElement || isSameElement;
   const isToDummyElement = toElement.id === "driver-dummy-element";
   const isFromDummyElement = fromElement.id === "driver-dummy-element";
 
@@ -115,6 +116,8 @@ function transferHighlight(toElement: Element, toStep: DriveStep) {
   setState("activeStep", toStep);
   setState("activeElement", toElement);
 
+  const isSameElementAnimationEnabled = !isSameElement || !!getConfig("animateBetweenSameElements");
+
   const animate = () => {
     const transitionCallback = getState("__transitionCallback");
 
@@ -129,8 +132,9 @@ function transferHighlight(toElement: Element, toStep: DriveStep) {
     const timeRemaining = duration - elapsed;
     const isHalfwayThrough = timeRemaining <= duration / 2;
 
+
     if (toStep.popover && isHalfwayThrough && !isPopoverRendered && hasDelayedPopover) {
-      renderPopover(toElement, toStep);
+      renderPopover(toElement, toStep, isSameElementAnimationEnabled);
       isPopoverRendered = true;
     }
 
@@ -162,7 +166,7 @@ function transferHighlight(toElement: Element, toStep: DriveStep) {
 
   bringInView(toElement);
   if (!hasDelayedPopover && toStep.popover) {
-    renderPopover(toElement, toStep);
+    renderPopover(toElement, toStep, isSameElementAnimationEnabled);
   }
 
   fromElement.classList.remove("driver-active-element", "driver-no-interaction");

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -128,6 +128,8 @@ function transferHighlight(toElement: Element, toStep: DriveStep) {
       return;
     }
 
+    setState("__activeElement", toElement);
+
     const elapsed = Date.now() - start;
     const timeRemaining = duration - elapsed;
     const isHalfwayThrough = timeRemaining <= duration / 2;
@@ -154,7 +156,6 @@ function transferHighlight(toElement: Element, toStep: DriveStep) {
       setState("__previousStep", fromStep);
       setState("__previousElement", fromElement);
       setState("__activeStep", toStep);
-      setState("__activeElement", toElement);
     }
 
     window.requestAnimationFrame(animate);

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -44,6 +44,14 @@ function getStepElement(step: DriveStep): Element | null {
 export function highlight(step: DriveStep) {
   let elemObj = getStepElement(step);
 
+  if (!getConfig("overlayEnable")) {
+    document.body.classList.add("driver-no-overlay");
+  }
+
+  if (!getConfig("allowScroll")) {
+    document.body.classList.add("driver-no-scroll");
+  }
+
   // If the element is not found, we mount a 1px div
   // at the center of the screen to highlight and show
   // the popover on top of that. This is to show a

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -27,9 +27,22 @@ function mountDummyElement(): Element {
   return element;
 }
 
-export function highlight(step: DriveStep) {
+function getStepElement(step: DriveStep): Element | null {
   const { element } = step;
-  let elemObj = typeof element === "string" ? document.querySelector(element) : element;
+
+  if (typeof element === 'function') {
+    return element();
+  }
+  
+  if (typeof element === 'string') {
+    return document.querySelector(element);
+  }
+
+  return element ?? null;
+}
+
+export function highlight(step: DriveStep) {
+  let elemObj = getStepElement(step);
 
   // If the element is not found, we mount a 1px div
   // at the center of the screen to highlight and show

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -55,6 +55,9 @@ export function trackActiveElement(element: Element) {
 }
 
 export function refreshOverlay() {
+  const isOverlayEnabled = getConfig('overlayEnable')
+  if (!isOverlayEnabled) return;
+
   const activeStagePosition = getState("__activeStagePosition");
   const overlaySvg = getState("__overlaySvg");
 
@@ -90,6 +93,9 @@ function mountOverlay(stagePosition: StageDefinition) {
 }
 
 function renderOverlay(stagePosition: StageDefinition) {
+  const isOverlayEnabled = getConfig('overlayEnable')
+  if (!isOverlayEnabled) return;
+
   const overlaySvg = getState("__overlaySvg");
 
   // TODO: cancel rendering if element is not visible

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -225,7 +225,6 @@ export function renderPopover(element: Element, step: DriveStep, isAnimationEnab
   }
 
   repositionPopover(element, step);
-  bringInView(popoverWrapper);
 
   // Focus on the first focusable element in active element or popover
   const isToDummyElement = element.classList.contains("driver-dummy-element");

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -58,7 +58,7 @@ export function hidePopover() {
   popover.wrapper.style.display = "none";
 }
 
-export function renderPopover(element: Element, step: DriveStep) {
+export function renderPopover(element: Element, step: DriveStep, isAnimationEnabled: boolean = true) {
   let popover = getState("popover");
   if (popover) {
     document.body.removeChild(popover.wrapper);
@@ -150,6 +150,10 @@ export function renderPopover(element: Element, step: DriveStep) {
   // Reset any custom classes on the popover
   const customPopoverClass = step.popover?.popoverClass || getConfig("popoverClass") || "";
   popoverWrapper.className = `driver-popover ${customPopoverClass}`.trim();
+
+  if (!isAnimationEnabled) {
+    popoverWrapper.classList.add("driver-no-animation");
+  }
 
   // Handles the popover button clicks
   onDriverClick(

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -1,4 +1,4 @@
-import { bringInView, getFocusableElements } from "./utils";
+import { getFocusableElements } from "./utils";
 import { Config, DriverHook, getConfig } from "./config";
 import { getState, setState, State } from "./state";
 import { DriveStep } from "./driver";

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -268,6 +268,8 @@ function calculateTopForLeftRight(
   }
 ): number {
   const { elementDimensions, popoverDimensions, popoverPadding, popoverArrowDimensions } = config;
+  const shouldStickToViewport = getConfig('popoverStickToViewport');
+  const safeZone = shouldStickToViewport ? popoverArrowDimensions.width : Number.MIN_SAFE_INTEGER 
 
   if (alignment === "start") {
     return Math.max(
@@ -275,7 +277,7 @@ function calculateTopForLeftRight(
         elementDimensions.top - popoverPadding,
         window.innerHeight - popoverDimensions!.realHeight - popoverArrowDimensions.width
       ),
-      popoverArrowDimensions.width
+      safeZone
     );
   }
 
@@ -285,7 +287,7 @@ function calculateTopForLeftRight(
         elementDimensions.top - popoverDimensions?.realHeight + elementDimensions.height + popoverPadding,
         window.innerHeight - popoverDimensions?.realHeight - popoverArrowDimensions.width
       ),
-      popoverArrowDimensions.width
+      safeZone
     );
   }
 
@@ -295,7 +297,7 @@ function calculateTopForLeftRight(
         elementDimensions.top + elementDimensions.height / 2 - popoverDimensions?.realHeight / 2,
         window.innerHeight - popoverDimensions?.realHeight - popoverArrowDimensions.width
       ),
-      popoverArrowDimensions.width
+      safeZone
     );
   }
 
@@ -313,6 +315,8 @@ function calculateLeftForTopBottom(
   }
 ): number {
   const { elementDimensions, popoverDimensions, popoverPadding, popoverArrowDimensions } = config;
+  const shouldStickToViewport = getConfig('popoverStickToViewport');
+  const safeZone = shouldStickToViewport ? popoverArrowDimensions.width : Number.MIN_SAFE_INTEGER 
 
   if (alignment === "start") {
     return Math.max(
@@ -320,7 +324,7 @@ function calculateLeftForTopBottom(
         elementDimensions.left - popoverPadding,
         window.innerWidth - popoverDimensions!.realWidth - popoverArrowDimensions.width
       ),
-      popoverArrowDimensions.width
+      safeZone
     );
   }
 
@@ -330,7 +334,7 @@ function calculateLeftForTopBottom(
         elementDimensions.left - popoverDimensions?.realWidth + elementDimensions.width + popoverPadding,
         window.innerWidth - popoverDimensions?.realWidth - popoverArrowDimensions.width
       ),
-      popoverArrowDimensions.width
+      safeZone
     );
   }
 
@@ -340,7 +344,7 @@ function calculateLeftForTopBottom(
         elementDimensions.left + elementDimensions.width / 2 - popoverDimensions?.realWidth / 2,
         window.innerWidth - popoverDimensions?.realWidth - popoverArrowDimensions.width
       ),
-      popoverArrowDimensions.width
+      safeZone
     );
   }
 
@@ -378,6 +382,8 @@ export function repositionPopover(element: Element, step: DriveStep) {
 
   const noneOptimal = !isTopOptimal && !isBottomOptimal && !isLeftOptimal && !isRightOptimal;
   let popoverRenderedSide: Side = requiredSide;
+
+  const shouldStickToViewport = getConfig('popoverStickToViewport');
 
   if (requiredSide === "top" && isTopOptimal) {
     isRightOptimal = isLeftOptimal = isBottomOptimal = false;
@@ -443,10 +449,11 @@ export function repositionPopover(element: Element, step: DriveStep) {
 
     popoverRenderedSide = "right";
   } else if (isTopOptimal) {
-    const topToSet = Math.min(
+    const topToSet = shouldStickToViewport ? Math.min(
       topValue,
       window.innerHeight - popoverDimensions!.realHeight - popoverArrowDimensions.width
-    );
+    ) : topValue;
+    
     let leftToSet = calculateLeftForTopBottom(requiredAlignment, {
       elementDimensions,
       popoverDimensions,
@@ -461,10 +468,10 @@ export function repositionPopover(element: Element, step: DriveStep) {
 
     popoverRenderedSide = "top";
   } else if (isBottomOptimal) {
-    const bottomToSet = Math.min(
+    const bottomToSet =  shouldStickToViewport ? Math.min(
       bottomValue,
       window.innerHeight - popoverDimensions?.realHeight - popoverArrowDimensions.width
-    );
+    ) : bottomValue;
 
     let leftToSet = calculateLeftForTopBottom(requiredAlignment, {
       elementDimensions,


### PR DESCRIPTION
Hello,
I'd like to propose these new features:
- add new `overlayEnable` config option, enabled by default. This property allows library consumers to disable highlight overlay if they wish. (https://github.com/kamranahmedse/driver.js/commit/741f521a1548b294cab3c4ac0470ad26ecaf43de)
To keep the functionality of closing highlight when user clicks away I needed to add new window click listener when `overlayEnable` is set to `false` (https://github.com/kamranahmedse/driver.js/commit/ffbe5050f9579b8996e40d75164775927e483b4e)
- add new `popoverStickToViewport` config option, enabled by default. This property allows library consumers to disable popover viewport sticking. When it's set to `false` popover always stays next to the `step.element` (https://github.com/kamranahmedse/driver.js/commit/7fd1726411501ac38b431bf99d58d93757b6d3c6)
- allow to pass function which returns Element as step element config to allow better integration with frameworks like Vue.js which use element reference instead of `document.querySelector` (https://github.com/kamranahmedse/driver.js/commit/5d1ec417a9de44c18bc595872c6a406541e08b56)
- add new `allowScroll` config option, enabled by default. This property allows library consumers to disable body scrolling when driver is active (https://github.com/kamranahmedse/driver.js/pull/508/commits/2d48c134db3efc2fc303fd289dedc96c8fd8f4aa)
- add new `animateBetweenSameElements` config option, enabled by default. This property allows library consumers to disable popup animation when multiple steps are assigned to the same html element (https://github.com/kamranahmedse/driver.js/pull/508/commits/be29918ef80e982595898fd0b74b733b2b9dfd62)
- fixed wrong active element on `requireRefresh` calls which resulted in broken layout (video of the issue -  https://drive.google.com/file/d/1JjQZuctRSwiBExAQDDFbALvIrsjdqHKK/view?usp=sharing) (https://github.com/kamranahmedse/driver.js/pull/508/commits/b11d4e22c811cd464ed51937a0a298e6acfa31cc)
- do not scroll to popover as we already scroll to `step.element` - this fixes the issue where user could make it so `element` is not visible at all on the page - https://drive.google.com/file/d/1FDr8yNEsNc6onkIVNBBykxwFU5uCDEdD/view?usp=sharing (https://github.com/kamranahmedse/driver.js/pull/508/commits/c86bf598f432cbc482752ad3296f2661f436103b)

I've added interactive examples of config options in `index.html`