### PR TITLE
add onnextstepcalled and on previousstepcalled booleans

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -162,6 +162,9 @@ export function driver(options: Config = {}) {
       return;
     }
 
+    setState("isNextStepCalled", false);
+    setState("isPreviousStepCalled", false);
+
     setState("__activeOnDestroyed", document.activeElement as HTMLElement);
     setState("activeIndex", stepIndex);
 
@@ -207,12 +210,14 @@ export function driver(options: Config = {}) {
               if (!hasNextStep) {
                 destroy();
               } else {
+                setState("isNextStepCalled", true);
                 drive(stepIndex + 1);
               }
             },
         onPrevClick: onPrevClick
           ? onPrevClick
           : () => {
+              setState("isPreviousStepCalled", true);
               drive(stepIndex - 1);
             },
         onCloseClick: onCloseClick

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,6 +11,9 @@ export type State = {
   previousElement?: Element;
   previousStep?: DriveStep;
 
+  isNextStepCalled?: boolean;
+  isPreviousStepCalled?: boolean;
+
   popover?: PopoverDOM;
 
   // actual values considering the animation


### PR DESCRIPTION
### Why We Need `isNextStepCalled` and `isPreviousStepCalled` in `driver.js`

#### What are `isNextStepCalled` and `isPreviousStepCalled`?
- **`isNextStepCalled`**: This is a flag to indicate if the function to move to the next step has been called.
- **`isPreviousStepCalled`**: This is a flag to indicate if the function to move to the previous step has been called.

#### Why are they useful?

1. **Better Tracking**:
   - These flags help us keep track of user navigation. We can know if the user tried to move forward or backward, which is helpful for debugging.

2. **Custom Actions**:
   - We can use these flags to trigger specific actions. For example, if `isNextStepCalled` is true, we might want to save the user's progress or show a message.

3. **Improved Control**:
   - They give us more control over the tour. We can make decisions based on whether the user moved to the next or previous step, ensuring a smoother experience.

## Sample usage
  ```javascript
{
      element: '#form-stepper-next-button',
      popover: {
        title: 'Data',
        description:
          'Some description',
        side: 'bottom',
        align: 'center',
      },
      onDeselected(el, step, opts) {
        if (opts.state.isNextStepCalled) {
          document.getElementById("next-button");
        }
        if (opts.state.isPreviousStepCalled) {
          document.getElementById("previous-button");
        }
      },
    }
  ```

#### Summary
Adding `isNextStepCalled` and `isPreviousStepCalled` helps us track and control user navigation more effectively, making the tour experience better and easier to manage.

---