### PR TITLE
add onnextstepcalled and on previousstepcalled booleans

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -40,6 +40,7 @@ export function driver(options: Config = {}) {
   }
 
   function moveNext() {
+    setState("isNextStepCalled", true);
     const activeIndex = getState("activeIndex");
     const steps = getConfig("steps") || [];
     if (typeof activeIndex === "undefined") {
@@ -55,6 +56,7 @@ export function driver(options: Config = {}) {
   }
 
   function movePrevious() {
+    setState("isPreviousStepCalled", true);
     const activeIndex = getState("activeIndex");
     const steps = getConfig("steps") || [];
     if (typeof activeIndex === "undefined") {
@@ -150,6 +152,7 @@ export function driver(options: Config = {}) {
 
   function drive(stepIndex: number = 0) {
     const steps = getConfig("steps");
+
     if (!steps) {
       console.error("No steps to drive through");
       destroy();
@@ -158,7 +161,6 @@ export function driver(options: Config = {}) {
 
     if (!steps[stepIndex]) {
       destroy();
-
       return;
     }
 
@@ -207,12 +209,16 @@ export function driver(options: Config = {}) {
               if (!hasNextStep) {
                 destroy();
               } else {
+                setState("isNextStepCalled", true);
+                setState("isPreviousStepCalled", false);
                 drive(stepIndex + 1);
               }
             },
         onPrevClick: onPrevClick
           ? onPrevClick
           : () => {
+              setState("isPreviousStepCalled", true);
+              setState("isNextStepCalled", false);
               drive(stepIndex - 1);
             },
         onCloseClick: onCloseClick
@@ -232,9 +238,6 @@ export function driver(options: Config = {}) {
     const activeOnDestroyed = getState("__activeOnDestroyed");
 
     const onDestroyStarted = getConfig("onDestroyStarted");
-    // `onDestroyStarted` is used to confirm the exit of tour. If we trigger
-    // the hook for when user calls `destroy`, driver will get into infinite loop
-    // not causing tour to be destroyed.
     if (withOnDestroyStartedHook && onDestroyStarted) {
       const isActiveDummyElement = !activeElement || activeElement?.id === "driver-dummy-element";
       onDestroyStarted(isActiveDummyElement ? undefined : activeElement, activeStep!, {

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,6 +11,9 @@ export type State = {
   previousElement?: Element;
   previousStep?: DriveStep;
 
+  isNextStepCalled?: boolean;
+  isPreviousStepCalled?: boolean;
+
   popover?: PopoverDOM;
 
   // actual values considering the animation


### PR DESCRIPTION
### Why We Need `isNextStepCalled` and `isPreviousStepCalled` in `driver.js`

#### What are `isNextStepCalled` and `isPreviousStepCalled`?
- **`isNextStepCalled`**: This is a flag to indicate if the function to move to the next step has been called.
- **`isPreviousStepCalled`**: This is a flag to indicate if the function to move to the previous step has been called.

#### Why are they useful?

1. **Better Tracking**:
   - These flags help us keep track of user navigation. We can know if the user tried to move forward or backward, which is helpful for making UI changes during the tour.

2. **Custom Actions**:
   - We can use these flags to trigger specific actions. For example, if `isNextStepCalled` is true, we might want to save the user's progress or show a message, go to the next step in a form wizard etc..

3. **Improved Control**:
   - They give us more control over the tour. We can make decisions based on whether the user moved to the next or previous step, ensuring a smoother experience.

## Sample usage
  ```javascript
{
      element: '#form-stepper-next-button',
      popover: {
        title: 'Data',
        description:
          'Some description',
        side: 'bottom',
        align: 'center',
      },
      onDeselected(el, step, opts) {
        if (opts.state.isNextStepCalled) {
          document.getElementById("next-button");
        }
        if (opts.state.isPreviousStepCalled) {
          document.getElementById("previous-button");
        }
      },
    }
  ```

#### Summary
Adding `isNextStepCalled` and `isPreviousStepCalled` helps us track and control user navigation more effectively, making the tour experience better and easier to manage.

---