### PR TITLE
feat: add 'data' property to DriveStep for custom logic support

### DIFF
--- a/docs/src/content/guides/configuration.mdx
+++ b/docs/src/content/guides/configuration.mdx
@@ -201,6 +201,9 @@ type DriveStep = {
   // Whether to disable interaction with the highlighted element. (default: false)
   disableActiveInteraction?: boolean;
 
+  // Arbitrary data that you can pass to the step in order to support complex custom logic in hooks. 
+  data?: Record<string, any>;
+
   // Callback when the current step is deselected,
   // about to be highlighted or highlighted.
   // Each callback receives the following parameters:

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -14,6 +14,7 @@ export type DriveStep = {
   onDeselected?: DriverHook;
   popover?: Popover;
   disableActiveInteraction?: boolean;
+  data?: Record<string, any>;
 };
 
 export function driver(options: Config = {}) {


### PR DESCRIPTION
Before it was not possible to pass custom data to the `DriveStep` interface. This limits the possiblities within a hook to execute custom logic based on the current step.

Fixes #539