### PR TITLE
Update CDN example version to 1.3.1

### DIFF
--- a/docs/src/components/CodeSample.tsx
+++ b/docs/src/components/CodeSample.tsx
@@ -53,7 +53,7 @@ export function CodeSample(props: CodeSampleProps) {
   const { heading, id, children, buttonText = "Show me an Example", className, config, highlight, tour } = props;
 
   if (id === "demo-hook-theme") {
-    config!.onPopoverRendered = attachFirstButton;
+    config!.onPopoverRender = attachFirstButton;
   }
 
   function onClick() {

--- a/docs/src/components/Examples.astro
+++ b/docs/src/components/Examples.astro
@@ -499,7 +499,7 @@ import { ExampleButton } from "./ExampleButton";
       element: '#customizing-popover',
       popover: {
         title: "Customizing Popover",
-        description: "Add your own class using `popoverClass` or use `onPopoverRendered` to get full control over the popover. <br /><br /> Visit these pages which cover <a class='font-medium underline' href='/docs/styling-popover'>styling</a> and <a class='font-medium underline' href='/docs/buttons'>customizing popovers</a> in detail.",
+        description: "Add your own class using `popoverClass` or use `onPopoverRender` to get full control over the popover. <br /><br /> Visit these pages which cover <a class='font-medium underline' href='/docs/styling-popover'>styling</a> and <a class='font-medium underline' href='/docs/buttons'>customizing popovers</a> in detail.",
         side: 'top',
         align: 'start'
       }

--- a/docs/src/content/guides/installation.mdx
+++ b/docs/src/content/guides/installation.mdx
@@ -17,11 +17,11 @@ pnpm install driver.js
 yarn add driver.js
 ```
 
-Alternatively, you can use CDN and include the script in your HTML file:
+Alternatively, you can use a CDN and include the script in your HTML file:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/driver.js@1.0.1/dist/driver.js.iife.js"></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/driver.js@1.0.1/dist/driver.css"/>
+<script src="https://cdn.jsdelivr.net/npm/driver.js@1.3.1/dist/driver.js.iife.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/driver.js@1.3.1/dist/driver.css"/>
 ```
 
 ## Start Using


### PR DESCRIPTION
This PR updates the CDN links to version 1.3.1 on the installation documentation page and closes #541.

I also fixed two instances of the old `onPopoverRendered` hook still being used which was renamed to `onPopoverRender` in version 1.0.3 and caused one of the examples on the [Popover Buttons](https://driverjs.com/docs/buttons) page to not work anymore and was the primary reason I even found out about the outdated CDN links.