### PR TITLE
Fix custom buttons example

### DIFF
--- a/docs/src/components/CodeSample.tsx
+++ b/docs/src/components/CodeSample.tsx
@@ -53,7 +53,7 @@ export function CodeSample(props: CodeSampleProps) {
   const { heading, id, children, buttonText = "Show me an Example", className, config, highlight, tour } = props;
 
   if (id === "demo-hook-theme") {
-    config!.onPopoverRendered = attachFirstButton;
+    config!.onPopoverRender = attachFirstButton;
   }
 
   function onClick() {

--- a/docs/src/components/Examples.astro
+++ b/docs/src/components/Examples.astro
@@ -499,7 +499,7 @@ import { ExampleButton } from "./ExampleButton";
       element: '#customizing-popover',
       popover: {
         title: "Customizing Popover",
-        description: "Add your own class using `popoverClass` or use `onPopoverRendered` to get full control over the popover. <br /><br /> Visit these pages which cover <a class='font-medium underline' href='/docs/styling-popover'>styling</a> and <a class='font-medium underline' href='/docs/buttons'>customizing popovers</a> in detail.",
+        description: "Add your own class using `popoverClass` or use `onPopoverRender` to get full control over the popover. <br /><br /> Visit these pages which cover <a class='font-medium underline' href='/docs/styling-popover'>styling</a> and <a class='font-medium underline' href='/docs/buttons'>customizing popovers</a> in detail.",
         side: 'top',
         align: 'start'
       }


### PR DESCRIPTION
This PR changes the two remaining mentions of the old hook name `onPopoverRendered` to `onPopoverRender`.
Closes #543 
