### PR TITLE
FIX : prevent tour from closing on left arrow key at first step

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -81,6 +81,7 @@ export function driver(options: Config = {}): Driver {
 
   function movePrevious() {
     const activeIndex = getState("activeIndex");
+    if (activeIndex === 0) return;
     const steps = getConfig("steps") || [];
     if (typeof activeIndex === "undefined") {
       return;
@@ -182,10 +183,9 @@ export function driver(options: Config = {}): Driver {
       destroy();
       return;
     }
-
+    if (stepIndex < 0) return;
     if (!steps[stepIndex]) {
       destroy();
-
       return;
     }
 

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -6,6 +6,8 @@ import { destroyHighlight, highlight } from "./highlight";
 import { destroyEmitter, listen } from "./emitter";
 import { getState, resetState, setState } from "./state";
 import "./driver.css";
+import { InvalidDriverActionError } from "./errors";
+import { DRIVER_MARKER, isDriver } from "./utils";
 
 export type DriveStep = {
   element?: string | Element | (() => Element);
@@ -38,6 +40,7 @@ export interface Driver {
   hasPreviousStep: () => boolean;
   highlight: (step: DriveStep) => void;
   destroy: () => void;
+  [DRIVER_MARKER]: true;
 }
 
 export function driver(options: Config = {}): Driver {
@@ -72,6 +75,10 @@ export function driver(options: Config = {}): Driver {
     }
 
     const nextStepIndex = activeIndex + 1;
+    // @ts-ignore
+    if (isDriver(this) && nextStepIndex >= steps.length) {
+        throw new InvalidDriverActionError("Cannot move to next step. Already at the last step.");
+    }
     if (steps[nextStepIndex]) {
       drive(nextStepIndex);
     } else {
@@ -81,13 +88,15 @@ export function driver(options: Config = {}): Driver {
 
   function movePrevious() {
     const activeIndex = getState("activeIndex");
-    if (activeIndex === 0) return;
     const steps = getConfig("steps") || [];
     if (typeof activeIndex === "undefined") {
       return;
     }
 
     const previousStepIndex = activeIndex - 1;
+    if (previousStepIndex < 0) {
+      throw new InvalidDriverActionError("Cannot move to previous step. Already at the first step.");
+    }
     if (steps[previousStepIndex]) {
       drive(previousStepIndex);
     } else {
@@ -97,6 +106,10 @@ export function driver(options: Config = {}): Driver {
 
   function moveTo(index: number) {
     const steps = getConfig("steps") || [];
+
+    if (index < 0 || index >= steps.length) {
+      throw new RangeError();
+    }
 
     if (steps[index]) {
       drive(index);
@@ -183,7 +196,9 @@ export function driver(options: Config = {}): Driver {
       destroy();
       return;
     }
-    if (stepIndex < 0) return;
+    if (stepIndex < 0 || stepIndex >= steps.length) {
+      throw new RangeError();
+    }
     if (!steps[stepIndex]) {
       destroy();
       return;
@@ -370,6 +385,7 @@ export function driver(options: Config = {}): Driver {
     destroy: () => {
       destroy(false);
     },
+    [DRIVER_MARKER]: true,
   };
 
   setCurrentDriver(api);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,12 @@
+export class InvalidDriverActionError extends Error {
+  constructor(errorMessage: string) {
+    super(errorMessage);
+    this.name = "InvalidDriverActionError";
+
+    Object.setPrototypeOf(this, InvalidDriverActionError.prototype);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InvalidDriverActionError);
+    }
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { getConfig } from "./config";
+import { Driver } from "./driver";
 
 export function easeInOutQuad(elapsed: number, initialValue: number, amountOfChange: number, duration: number): number {
   if ((elapsed /= duration / 2) < 1) {
@@ -64,4 +65,10 @@ function isElementInView(element: Element) {
 
 export function isElementVisible(el: HTMLElement) {
   return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+}
+
+export const DRIVER_MARKER = Symbol("Driver");
+
+export function isDriver(obj: any): obj is Driver {
+  return obj && obj[DRIVER_MARKER] === true;
 }


### PR DESCRIPTION
- **Prevented the tour from being destroyed when pressing the left arrow key on the first step.**

- **Added checks in:**
     - drive() – exits early if stepIndex < 0.
     - movePrevious() – exits if activeIndex === 0.

- **Didn't add the check in handleArrowLeft() to allow client-defined onPrevClick callbacks to run as expected.**

Fixes #564

