### PR TITLE
update: Adds a missing type option in the guide for the `configuration`

### DIFF
--- a/docs/src/content/guides/configuration.mdx
+++ b/docs/src/content/guides/configuration.mdx
@@ -200,7 +200,7 @@ type DriveStep = {
   // a function that returns a DOM Element, or a CSS selector.
   // If this is a selector, the first matching
   // element will be highlighted.
-  element: Element | string | (() => Element);
+  element?: Element | string | (() => Element);
 
   // The popover configuration for this step.
   // Look at the Popover Configuration section

--- a/docs/src/content/guides/configuration.mdx
+++ b/docs/src/content/guides/configuration.mdx
@@ -199,7 +199,7 @@ type DriveStep = {
   // This can be a DOM element, or a CSS selector.
   // If this is a selector, the first matching
   // element will be highlighted.
-  element: Element | string;
+  element: Element | string | (() => Element);
 
   // The popover configuration for this step.
   // Look at the Popover Configuration section

--- a/docs/src/content/guides/configuration.mdx
+++ b/docs/src/content/guides/configuration.mdx
@@ -196,7 +196,8 @@ Drive step is the configuration object passed to the `highlight` method or the `
 ```typescript
 type DriveStep = {
   // The target element to highlight.
-  // This can be a DOM element, or a CSS selector.
+  // This can be a DOM element,
+  // a function that returns a DOM Element, or a CSS selector.
   // If this is a selector, the first matching
   // element will be highlighted.
   element: Element | string | (() => Element);


### PR DESCRIPTION
This change adds a missing type option to `element` property in the configuration to accept a function that returns an Element.