### PR TITLE
call step's onNextClick handler when clicking the

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -60,7 +60,18 @@ export function driver(options: Config = {}): Driver {
     }
 
     if (overlayClickBehavior === "nextStep") {
-      moveNext();
+      const step = getState().activeStep!;
+      const onNextClick = step?.popover?.onNextClick || getConfig("onNextClick");
+      if (onNextClick){
+        return onNextClick(undefined, step, {
+          config: getConfig(),
+          state: getState(),
+          driver: getCurrentDriver(),
+        });
+      }
+      else {
+        moveNext();
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes the issue [576](https://github.com/kamranahmedse/driver.js/issues/576).
It checks if the current step has onNextClick() listener and calls it instead of just calling moveNext().
This allows to control moveNext behavior from the step listener (as described in documentation) even when overlayClickBehavior: "nextStep".