### PR TITLE
Fix typo in button guide documentation

### DIFF
--- a/docs/src/content/guides/buttons.mdx
+++ b/docs/src/content/guides/buttons.mdx
@@ -11,7 +11,7 @@ You can use the `showButtons` option to choose which buttons to show in the popo
 <div id="driver-note" className="mb-5">
   > **Note:** When using the `highlight` method to highlight a single element, the only button shown is the `close`
   button. However, you can use the `showButtons` option to show other buttons as well. But the buttons won't do
-  anything. You will have to use the `onNextClick` and `onPreviousClick` callbacks to implement the functionality.
+  anything. You will have to use the `onNextClick` and `onPrevClick` callbacks to implement the functionality.
 </div>
 
 <div className='flex flex-col gap-1'>


### PR DESCRIPTION
`onPreviousClick` is not a valid callback. The correct syntax is `onPrevClick`.